### PR TITLE
Compatibility with shortcode-core v2.3.1

### DIFF
--- a/gravstrap.php
+++ b/gravstrap.php
@@ -93,7 +93,7 @@ class GravstrapPlugin extends Plugin
     
     private function pageShortcodesToTwigVariable(Page $page)
     {
-        $contentMeta = $page->getContentMeta('shortcode-meta');
+        $contentMeta = $page->getContentMeta();
         if (null === $contentMeta || ! array_key_exists("shortcode", $contentMeta) || null === $shortcodes = $contentMeta["shortcode"]) {
             return;
         }
@@ -120,7 +120,7 @@ class GravstrapPlugin extends Plugin
     private function addAssets(Page $page)
     {
         // get the meta and check for assets
-        $meta = $page->getContentMeta('shortcode-meta');
+        $meta = $page->getContentMeta();
         if (!isset($meta['shortcode-assets'])) {
             return;
         }

--- a/gravstrap.php
+++ b/gravstrap.php
@@ -93,7 +93,7 @@ class GravstrapPlugin extends Plugin
     
     private function pageShortcodesToTwigVariable(Page $page)
     {
-        $contentMeta = $page->getContentMeta();
+        $contentMeta = $page->getContentMeta('shortcodeMeta');
         if (null === $contentMeta || ! array_key_exists("shortcode", $contentMeta) || null === $shortcodes = $contentMeta["shortcode"]) {
             return;
         }
@@ -120,12 +120,12 @@ class GravstrapPlugin extends Plugin
     private function addAssets(Page $page)
     {
         // get the meta and check for assets
-        $meta = $page->getContentMeta();
-        if (!isset($meta['shortcode-assets'])) {
+        $meta = $page->getContentMeta('shortcodeMeta');
+        if (!isset($meta['shortcodeAssets'])) {
             return;
         }
         
-        $assets = (array) $meta['shortcode-assets'];
+        $assets = (array) $meta['shortcodeAssets'];
         foreach($assets as $type => $asset) {
             switch ($type) {
                 case 'css':


### PR DESCRIPTION
Some issues happens with last Grav release (1.1.0 stable), shortcode-core (v2.3.1) and Gravstrap plugin.

In fact, gravstrap plugin can't view used shortcodes.
This PR fix theses issues.
